### PR TITLE
Add creating sheets code to the InsertWorksheet()

### DIFF
--- a/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
@@ -311,9 +311,10 @@ to the [WorkbookPart](https://msdn.microsoft.com/en-us/library/office/documentfo
         // Add a new worksheet part to the workbook.
         WorksheetPart newWorksheetPart = workbookPart.AddNewPart<WorksheetPart>();
         newWorksheetPart.Worksheet = new Worksheet(new SheetData());
+        Sheets sheets = workbookPart.Workbook.AppendChild<Sheets>(new Sheets());
+        
         newWorksheetPart.Worksheet.Save();
 
-        Sheets sheets = workbookPart.Workbook.GetFirstChild<Sheets>();
         string relationshipId = workbookPart.GetIdOfPart(newWorksheetPart);
 
         // Get a unique ID for the new sheet.


### PR DESCRIPTION
Sheets sheets = workbookPart.Workbook.GetFirstChild<Sheets>();
This code in the InsertWoksheet function threw an exception because the Sheets type child is not exist.
So I added an adding Sheets line and put the return value to the variable sheets.